### PR TITLE
Add workaround for Lyon bug with short path segments

### DIFF
--- a/src/collab.rs
+++ b/src/collab.rs
@@ -7,7 +7,9 @@ use crate::{Chalk, Stats};
 use bevy::prelude::*;
 use bevy::utils::{Duration, HashMap, Instant};
 use bevy_matchbox::prelude::*;
-use bevy_prototype_lyon::prelude::{GeometryBuilder, ShapeBundle, Stroke};
+use bevy_prototype_lyon::prelude::{
+    GeometryBuilder, LineCap, LineJoin, ShapeBundle, Stroke, StrokeOptions,
+};
 use bevy_prototype_lyon::shapes;
 use serde::{Deserialize, Serialize};
 
@@ -341,7 +343,13 @@ fn make_peer_cursor(color: Srgba, id: CollabId) -> (ShapeBundle, Stroke, PeerCur
         ..default()
     };
 
-    let stroke = Stroke::new(color, 10.0);
+    let stroke = Stroke {
+        color: color.into(),
+        options: StrokeOptions::default()
+            .with_line_width(10.0)
+            .with_line_join(LineJoin::Round)
+            .with_line_cap(LineCap::Round),
+    };
     let peer_cursor = PeerCursor::new(id);
 
     (shape, stroke, peer_cursor)

--- a/src/drawing.rs
+++ b/src/drawing.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::cast_precision_loss)]
 
 use crate::Chalk;
-use bevy::prelude::*;
+use bevy::{math::NormedVectorSpace, prelude::*};
 
 use bevy_prototype_lyon::prelude::*;
 
@@ -25,12 +25,31 @@ fn update(
     time: Res<Time>,
 ) {
     for (chalk, mut path, mut stroke, mut polyline) in &mut chalk_q {
-        let updated = chalk.pressed && chalk.updated;
+        let updated = chalk.pressed
+            && chalk.updated
+            && polyline.points.last() != Some(&Vec2::new(chalk.x as f32, chalk.y as f32));
 
         stroke.color = chalk.color.into();
         stroke.options.line_width = chalk.line_width as f32;
 
         if updated {
+            if let Some(last_points) = polyline.points.last_chunk::<2>().copied() {
+                // Check whether adding the next point will cause Lyon to triangulate the path incorrectly.
+                // If it will, complete the path and start a new path to avoid the bug.
+                if triggers_lyon_bug(
+                    &[
+                        last_points[0],
+                        last_points[1],
+                        Vec2::new(chalk.x as f32, chalk.y as f32),
+                    ],
+                    chalk.line_width as f32 / 2.0, // Circle radius is half the line width
+                ) {
+                    complete_pending_path(&mut polyline, &mut commands, &chalk, &time);
+                    polyline.points.push(last_points[1]);
+                }
+            }
+
+            // Extend the path normally.
             add_point(&mut polyline, &chalk);
         }
 
@@ -87,7 +106,13 @@ fn complete_pending_path(
             spatial: transform.into(),
             ..default()
         },
-        Stroke::new(chalk.color, chalk.line_width as f32),
+        Stroke {
+            color: chalk.color.into(),
+            options: StrokeOptions::default()
+                .with_line_width(chalk.line_width as f32)
+                .with_line_join(LineJoin::Round)
+                .with_line_cap(LineCap::Round),
+        },
         Fill::color(Color::NONE),
         Completed,
     ));
@@ -111,7 +136,13 @@ pub(crate) fn make_chalk(chalk: Chalk) -> (ShapeBundle, Stroke, Fill, Polyline, 
             spatial: transform.into(),
             ..default()
         },
-        Stroke::new(Color::WHITE, 10.0),
+        Stroke {
+            color: Color::WHITE,
+            options: StrokeOptions::default()
+                .with_line_width(10.0)
+                .with_line_join(LineJoin::Round)
+                .with_line_cap(LineCap::Round),
+        },
         Fill::color(Color::NONE),
         Polyline::default(),
         Pending,
@@ -178,4 +209,45 @@ fn handle_clear_event(
     if clear {
         despawn_all_completed_lines(&mut commands, &lines);
     }
+}
+
+/// Returns whether Lyon would triangulate the given 3-vertex path incorrectly.
+/// This path should not consist of any segments of length 0 (so adjacent points should not be repeated).
+fn triggers_lyon_bug(points: &[Vec2; 3], stroke_radius: f32) -> bool {
+    // The issue at hand is https://github.com/nical/lyon/issues/891.
+    // Lyon expects the stroke radius to be small and for each segment of the path to be long.
+    // When this is the case, the inner corner between two path segments can be computed as
+    // the intersection between two lines (the ones offset by `stroke_radius` from the line segments forming the path).
+    // However, this assumption does not hold when the stroke radius is too large compared to the line segment lengths.
+
+    // Here is the math to determine when this is a problem:
+    // Lyon expects the inner corner to be `stroke_radius` units away from both line segments, so if we
+    // drop a perpendicular from the expected inner corner location to each of the two line segments,
+    // the length of the perpendicular will be `stroke_radius`, and the distance from the landing point
+    // of the perpendicular to the origin will be the cutoff in which line segments shorter than that
+    // will cause buggy behavior in Lyon.
+
+    // If we draw a diagram illustrating the above as well as connecting the inner corner to `points[1]` with a line
+    // segment, two congruent triangles will appear, bisecting the angle between the two main line segments.
+    // This produces the following formula:
+    // `tan(theta / 2) == stroke_radius / min_length`
+    // which is equivalent to
+    // `min_length * sin(theta / 2) == cos(theta / 2) * stroke_radius`
+    // which is equivalent to (because both sides are positive)
+    // `min_length^2 * sin^2(theta / 2) == cos^2(theta / 2) * stroke_radius^2`
+
+    // The following code uses the above formula along with other trigonometric identities, being careful
+    // to avoid any possible division by 0 unless one of the path segments has length 0 (forbidden as a precondition).
+    // Square roots are also avoided in case floating point precision would result in the square root of a negative number.
+    let vector0 = points[0] - points[1];
+    let vector1 = points[2] - points[1];
+    let cos_angle = vector0.dot(vector1) / (vector0.norm() * vector1.norm());
+
+    let sqr_cos_half_angle = 1.0 + cos_angle;
+    let sqr_sin_half_angle = 1.0 - cos_angle;
+
+    let sqr_stroke_radius = stroke_radius * stroke_radius;
+
+    vector0.norm_squared() * sqr_sin_half_angle <= sqr_cos_half_angle * sqr_stroke_radius
+        || vector1.norm_squared() * sqr_sin_half_angle <= sqr_cos_half_angle * sqr_stroke_radius
 }


### PR DESCRIPTION
Fixes #16

As it may be a while before https://github.com/nical/lyon/issues/891 gets fixed due to the trickiness of the problem and general maintainer availability, this PR works around the bug instead by completing and starting a new path early whenever necessary to prevent polylines from being formed that would trigger the bug.

I did my best to make the math understandable, but the inability to put diagrams in code comments makes the explanation somewhat opaque.