### PR TITLE
Fix hidden in-progress strokes by turning off frustum culling for them

### DIFF
--- a/src/drawing.rs
+++ b/src/drawing.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::cast_precision_loss)]
 
 use crate::Chalk;
-use bevy::prelude::*;
+use bevy::{prelude::*, render::view::NoFrustumCulling};
 
 use bevy_prototype_lyon::prelude::*;
 
@@ -95,7 +95,7 @@ fn complete_pending_path(
     polyline.points.clear();
 }
 
-pub(crate) fn make_chalk(chalk: Chalk) -> (ShapeBundle, Stroke, Fill, Polyline, Pending, Chalk) {
+pub(crate) fn make_chalk(chalk: Chalk) -> impl Bundle {
     // An empty path
     let path = PathBuilder::new().build();
 
@@ -115,6 +115,7 @@ pub(crate) fn make_chalk(chalk: Chalk) -> (ShapeBundle, Stroke, Fill, Polyline, 
         Fill::color(Color::NONE),
         Polyline::default(),
         Pending,
+        NoFrustumCulling,
         chalk,
     )
 }


### PR DESCRIPTION
Fixes #28 by turning off frustum culling, since this behaves in unexpected ways with changing meshes (https://github.com/bevyengine/bevy/issues/4294).